### PR TITLE
Fix options format in thrift gen command

### DIFF
--- a/Common/src/main/resources/BidiMessages.thrift
+++ b/Common/src/main/resources/BidiMessages.thrift
@@ -1,4 +1,4 @@
-#!/usr/local/bin/thrift --gen java:beans:hashcode -O ../
+#!/usr/local/bin/thrift --gen java:beans,hashcode -O ../
 
 namespace java com.joelpm.bidiMessages.generated
 


### PR DESCRIPTION
The options for same language are supposed to be separated by a comma, I was facing issues when I copy pasted stuff for a project for mine
